### PR TITLE
Added option to make notification persist

### DIFF
--- a/js/notificationFx.js
+++ b/js/notificationFx.js
@@ -91,8 +91,8 @@
 
 		// dismiss after [options.ttl]ms
 		var self = this;
-		// checks to make sure ttl is not set to false in notification
-		if(this.options.ttl) {
+		
+		if(this.options.ttl) { // checks to make sure ttl is not set to false in notification initialization
 			this.dismissttl = setTimeout( function() {
 				if( self.active ) {
 					self.dismiss();


### PR DESCRIPTION
If the notification is initialized with a ttl of false, the notification will remain until the user closes the notification by clicking the close button.
