### PR TITLE
Fix for IE9

### DIFF
--- a/js/notificationFx.js
+++ b/js/notificationFx.js
@@ -146,7 +146,7 @@
 				if( ev.target !== self.ntf ) return false;
 				this.removeEventListener( animEndEventName, onEndAnimationFn );
 			}
-			self.options.wrapper.removeChild( this );
+			self.options.wrapper.removeChild( self.ntf );
 		};
 
 		if( support.animations ) {


### PR DESCRIPTION
IE9 throw "No such interface supported" when you try dismiss "Slide on top" notification. This change fix problem.